### PR TITLE
Fix repo and website urls

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -105,12 +105,12 @@ version = "0.0"
 
 # A link to latest version of the docs. Used in the "version-banner" partial to
 # point people to the main doc site.
-url_latest_version = "https://example.com"
+url_latest_version = "https://transhub.se/docs/"
 
 # Repository configuration (URLs for in-page links to opening issues and suggesting changes)
-github_repo = "https://github.com/google/docsy-example"
+github_repo = "https://github.com/Olivia5k/trans-hub/"
 # An optional link to a related project repo. For example, the sibling repository where your product code lives.
-github_project_repo = "https://github.com/google/docsy"
+github_project_repo = "https://github.com/Olivia5k/trans-hub/"
 
 # Specify a value here if your content directory is not in your repo's root directory
 # github_subdir = ""


### PR DESCRIPTION
Hii Olivia, I made a small fix such that clicking the "Last modified" link below an article redirects to the correct repo and not the doxy example repo. This was also an issue with the "View page source", "Edit this page", … links. I didn't test the pull request locally but I think it should be fine ^^'